### PR TITLE
Update readme to reflect js-graphql-intellij-plugin 2.0 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The easiest way to configure your development environment with your GraphQL sche
 * [graphql-language-service](https://github.com/graphql/graphql-language-service) - An interface for building GraphQL language services for IDEs (_pending_)
 
 ### Editors
-* [js-graphql-intellij-plugin](https://github.com/jimkyndemeyer/js-graphql-intellij-plugin) - GraphQL language support for IntelliJ IDEA and WebStorm, including Relay.QL tagged templates in JavaScript and TypeScript (_pending_)
+* [js-graphql-intellij-plugin 2.0](https://github.com/jimkyndemeyer/js-graphql-intellij-plugin) - GraphQL language support for WebStorm, IntelliJ IDEA and other IDEs based on the IntelliJ Platform.
 * [atom-language-graphql](https://github.com/rmosolgo/language-graphql) - GraphQL support for Atom text editor (_pending_)
 * [vscode-graphql](https://github.com/stephen/vscode-graphql) - GraphQL support for VSCode text editor
 


### PR DESCRIPTION
See https://github.com/jimkyndemeyer/js-graphql-intellij-plugin/releases/tag/2.0.0